### PR TITLE
Feature/#18

### DIFF
--- a/src/api/admin-event/admin-event.ts
+++ b/src/api/admin-event/admin-event.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
-interface EventPropType {
+export interface EventPropType {
+  id?: number;
   name?: string;
   image?: string;
   detailImage?: string;

--- a/src/api/popular-stay.ts
+++ b/src/api/popular-stay.ts
@@ -10,3 +10,10 @@ export const fetchPopularStay = createAsyncThunk(
     return response.data;
   }
 );
+
+export const getPopularStay = async () => {
+  const response = await axios.get(
+    `${process.env.REACT_APP_API_URL}/stations/likes`
+  );
+  return response.data;
+};

--- a/src/components/admin-event-modal/eventModal.component.tsx
+++ b/src/components/admin-event-modal/eventModal.component.tsx
@@ -140,6 +140,7 @@ const EventModal = (prop: PropType): JSX.Element => {
       alert('이벤트를 추가했습니다.');
       closeModal();
       queryClient.invalidateQueries(['getAllEvents']);
+      queryClient.invalidateQueries(['allEvents']);
     },
   });
 
@@ -148,6 +149,7 @@ const EventModal = (prop: PropType): JSX.Element => {
       alert('이벤트를 수정했습니다.');
       closeModal();
       queryClient.invalidateQueries(['getAllEvents']);
+      queryClient.invalidateQueries(['allEvents']);
     },
     onError: (error) => {
       console.log('error: ', error);

--- a/src/components/swiper/bannerSwiper.component.tsx
+++ b/src/components/swiper/bannerSwiper.component.tsx
@@ -7,12 +7,13 @@ import 'swiper/css/navigation';
 import 'swiper/css/pagination';
 import 'swiper/css/scrollbar';
 
-interface ImageUrlType {
-  imgUrlArr: string[];
-}
-
-export default function BannerSwiper({ imgUrlArr }: ImageUrlType): JSX.Element {
+export default function BannerSwiper(): JSX.Element {
   SwiperCore.use([Navigation, Pagination, Autoplay]);
+
+  const BANNER_IMAGES = [
+    'https://d2u1fvsvew9tft.cloudfront.net/plus/1658500098920이벤트배너.png',
+    'https://d2u1fvsvew9tft.cloudfront.net/plus/1658498830946이벤트배너2.png',
+  ];
 
   const [mainIndex, setMainIndex] = useState(0);
   const navigationPrevRef = useRef(null);
@@ -38,15 +39,13 @@ export default function BannerSwiper({ imgUrlArr }: ImageUrlType): JSX.Element {
 
   return (
     <Swiper {...swiperParams}>
-      {/* {imgUrlArr.map((item, index) => {
-        return <SwiperSlide key={index}>{item}</SwiperSlide>;
-      })} */}
-      <SwiperSlide>
-        <img src={imgUrlArr[0]} alt="이미지 배너" style={{ width: '100%' }} />
-      </SwiperSlide>
-      <SwiperSlide>
-        <img src={imgUrlArr[1]} alt="이미지 배너" style={{ width: '100%' }} />
-      </SwiperSlide>
+      {BANNER_IMAGES.map((el) => {
+        return (
+          <SwiperSlide key={el}>
+            <img src={el} alt="이미지 배너" style={{ width: '100%' }} />
+          </SwiperSlide>
+        );
+      })}
     </Swiper>
   );
 }

--- a/src/components/swiper/eventSwiper.component.tsx
+++ b/src/components/swiper/eventSwiper.component.tsx
@@ -1,8 +1,9 @@
 import { useRef, useState } from 'react';
-import { Swiper, SwiperSlide } from 'swiper/react';
+import { useQuery } from '@tanstack/react-query';
+import { SwiperSlide } from 'swiper/react';
 import SwiperCore, { Navigation, Pagination } from 'swiper';
-import { StayBaseType } from '../../store/modules/popular-stay/popularStay.type';
-
+import { getAllEvents } from '../../api/admin-event/admin-event';
+import { compareDates } from '../../utils/compareDates';
 import { ROUTES } from '../../routes/routes';
 
 import 'swiper/css';
@@ -24,40 +25,30 @@ import {
 
 import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
 
-interface SwiperDataType {
+export interface GetAllEventsSuccessResponse {
+  message: string;
+  statusCode: number;
+  data: EventsData[];
+}
+
+interface EventsData {
   id: number;
   name: string;
+  image: string;
+  detailImage: string;
   start_date: string;
   end_date: string;
   rate: number;
-  image: string;
-  minprice?: number;
-  maxprice?: number;
-  local?: {
-    id?: number;
-    name?: string;
-    classification?: string;
-  };
 }
 
-interface StayType extends StayBaseType {
-  start_date?: string;
-  end_date?: string;
-  rate?: number;
-}
-
-interface swiperDataArrType {
-  swiperDataArr: SwiperDataType[] | StayType[];
-}
-
-export default function SwiperComponent({
-  swiperDataArr,
-}: swiperDataArrType): JSX.Element {
+const EventSwiper = (): JSX.Element => {
   SwiperCore.use([Navigation, Pagination]);
 
   const [mainIndex, setMainIndex] = useState(0);
   const navigationPrevRef = useRef(null);
   const navigationNextRef = useRef(null);
+
+  const [eventsInProgress, setEventsInProgress] = useState<EventsData[]>([]);
 
   const swiperParams = {
     spaceBetween: 50,
@@ -80,47 +71,43 @@ export default function SwiperComponent({
     },
   };
 
-  console.log(swiperDataArr);
+  const { data } = useQuery<GetAllEventsSuccessResponse>(
+    ['allEvents'],
+    getAllEvents,
+    {
+      refetchOnWindowFocus: false,
+      retry: 0,
+
+      onSuccess: (data) => {
+        const eventsInProgress = data.data.filter((el) =>
+          compareDates(el.end_date)
+        );
+        setEventsInProgress(eventsInProgress);
+      },
+    }
+  );
 
   return (
     <SwiperContainer {...swiperParams}>
-      {swiperDataArr.map((item, index) => {
-        return (
-          <SwiperSlide key={index}>
-            <LinkEvent
-              to={
-                item?.rate
-                  ? `${ROUTES.EVENT.link}/${item.id}`
-                  : `${ROUTES.STAY.link}/${item.id}`
-              }
-            >
-              <SlideContainer>
-                <SlideImage
-                  className={item.name.includes('이벤트') ? 'event' : 'stay'}
-                  src={item.image}
-                />
-              </SlideContainer>
-              {item?.rate ? (
+      {data &&
+        eventsInProgress.map((item, index) => {
+          return (
+            <SwiperSlide key={index}>
+              <LinkEvent to={`${ROUTES.EVENT.link}/${item.id}`}>
+                <SlideContainer>
+                  <SlideImage src={item.image} />
+                </SlideContainer>
                 <SlideDescriptionContainer>
                   <SlideTitle>{item.name}</SlideTitle>
                   <StayDescription>{`${item?.start_date} ~ ${item?.end_date}`}</StayDescription>
                 </SlideDescriptionContainer>
-              ) : (
-                <SlideDescriptionContainer>
-                  <SlideTitle>{item.name}</SlideTitle>
-                  <StayDescription>
-                    <span>{item.local?.name}</span>
-                    <span>{`₩${item.minprice?.toLocaleString()} ~ ₩${item.maxprice?.toLocaleString()}`}</span>
-                  </StayDescription>
-                </SlideDescriptionContainer>
-              )}
-            </LinkEvent>
-          </SwiperSlide>
-        );
-      })}
+              </LinkEvent>
+            </SwiperSlide>
+          );
+        })}
 
       <NavigationButtonContainer
-        visible={swiperDataArr.length > 2 ? true : false}
+        visible={data && eventsInProgress.length > 2 ? true : false}
       >
         <NavigationButton ref={navigationPrevRef}>
           <IoIosArrowBack />
@@ -131,4 +118,6 @@ export default function SwiperComponent({
       </NavigationButtonContainer>
     </SwiperContainer>
   );
-}
+};
+
+export default EventSwiper;

--- a/src/components/swiper/staySwiper.component.tsx
+++ b/src/components/swiper/staySwiper.component.tsx
@@ -1,0 +1,119 @@
+import { useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { SwiperSlide } from 'swiper/react';
+import SwiperCore, { Navigation, Pagination } from 'swiper';
+import { getPopularStay } from '../../api/popular-stay';
+import { ROUTES } from '../../routes/routes';
+
+import 'swiper/css';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
+import 'swiper/css/scrollbar';
+
+import {
+  SwiperContainer,
+  SlideContainer,
+  SlideImage,
+  SlideTitle,
+  NavigationButtonContainer,
+  NavigationButton,
+  LinkEvent,
+  SlideDescriptionContainer,
+  StayDescription,
+} from './swiper.style';
+
+import { IoIosArrowBack, IoIosArrowForward } from 'react-icons/io';
+
+interface GetPopularStaySuccessResponse {
+  message: string;
+  statusCode: number;
+  data: StayData[];
+}
+
+interface StayData {
+  id: number;
+  name: string;
+  image: string;
+  minprice: number;
+  maxprice: number;
+  local: {
+    id: number;
+    name: string;
+    classification: string;
+  };
+}
+
+const StaySwiper = (): JSX.Element => {
+  SwiperCore.use([Navigation, Pagination]);
+
+  const [mainIndex, setMainIndex] = useState(0);
+  const navigationPrevRef = useRef(null);
+  const navigationNextRef = useRef(null);
+
+  const swiperParams = {
+    spaceBetween: 50,
+    slidesPerView: 1,
+    navigation: {
+      prevEl: navigationPrevRef.current,
+      nextEl: navigationNextRef.current,
+    },
+    onBeforeInit: (swiper: any) => {
+      swiper.params.navigation.prevEl = navigationPrevRef.current;
+      swiper.params.navigation.nextEl = navigationNextRef.current;
+      swiper.activeIndex = mainIndex;
+    },
+    onSlideChange: (e: any) => setMainIndex(e.activeIndex),
+
+    breakpoints: {
+      768: {
+        slidesPerView: 2,
+      },
+    },
+  };
+
+  const { data } = useQuery<GetPopularStaySuccessResponse>(
+    ['getPopularStay'],
+    getPopularStay,
+    {
+      refetchOnWindowFocus: false,
+      retry: 0,
+    }
+  );
+
+  return (
+    <SwiperContainer {...swiperParams}>
+      {data &&
+        data.data.map((item, index) => {
+          return (
+            <SwiperSlide key={index}>
+              <LinkEvent to={`${ROUTES.STAY.link}/${item.id}`}>
+                <SlideContainer>
+                  <SlideImage className="stay" src={item.image} />
+                </SlideContainer>
+                <SlideDescriptionContainer>
+                  <SlideTitle>{item.name}</SlideTitle>
+                  <StayDescription>
+                    <span>{item.local.name}</span>
+                    <span>{`₩${item.minprice.toLocaleString()} ~ ₩${item.maxprice.toLocaleString()}`}</span>
+                  </StayDescription>
+                </SlideDescriptionContainer>
+              </LinkEvent>
+            </SwiperSlide>
+          );
+        })}
+
+      <NavigationButtonContainer
+        visible={data && data.data.length > 2 ? true : false}
+      >
+        <NavigationButton ref={navigationPrevRef}>
+          <IoIosArrowBack />
+        </NavigationButton>
+        <NavigationButton ref={navigationNextRef}>
+          <IoIosArrowForward />
+        </NavigationButton>
+      </NavigationButtonContainer>
+    </SwiperContainer>
+  );
+};
+
+export default StaySwiper;

--- a/src/components/swiper/swiper.style.tsx
+++ b/src/components/swiper/swiper.style.tsx
@@ -22,7 +22,6 @@ export const LinkEvent = styled(Link)`
 
 export const SlideImage = styled.img`
   width: 100%;
-
   border-radius: 10px;
 
   &.stay {

--- a/src/routes/admin-event/adminEvent.component.tsx
+++ b/src/routes/admin-event/adminEvent.component.tsx
@@ -69,6 +69,7 @@ const AdminEvent = (): JSX.Element => {
   const eventDeleteMutate = useMutation(deleteEvent, {
     onSuccess: () => {
       queryClient.invalidateQueries(['getAllEvents']);
+      queryClient.invalidateQueries(['allEvents']);
       alert('이벤트를 삭제했습니다.');
     },
   });

--- a/src/routes/admin-event/adminEvent.component.tsx
+++ b/src/routes/admin-event/adminEvent.component.tsx
@@ -12,6 +12,7 @@ import {
   GetAllEventsSuccessResponse,
 } from '../../api/admin-event/admin-event.type';
 import { selectIsAdminEventModalOpen } from '../../store/modules/modal/modal.select';
+import { compareDates } from '../../utils/compareDates';
 import EventModal from '../../components/admin-event-modal/eventModal.component';
 import {
   Container,
@@ -51,37 +52,16 @@ const AdminEvent = (): JSX.Element => {
     detailImage: '',
   });
 
-  const getTodayDate = useCallback(() => {
-    let today = new Date();
-    let year = today.getFullYear();
-    let month = today.getMonth() + 1;
-    let date = today.getDate();
-
-    let todayDate = `${year}-${month < 10 ? `0${month}` : month}-${
-      date < 10 ? `0${date}` : date
-    }`;
-
-    return todayDate;
-  }, []);
-
-  const isEndedEvent = (todayDate: string, eventEndDate: string) => {
-    return todayDate > eventEndDate;
-  };
-
   useQuery<GetAllEventsSuccessResponse>(['getAllEvents'], getAllEvents, {
     refetchOnWindowFocus: false,
     retry: 0,
     onSuccess: (data) => {
-      const today = getTodayDate();
-
-      const eventsInProgress = data.data.filter(
-        (el) => !isEndedEvent(today, el.end_date)
+      const eventsInProgress = data.data.filter((el) =>
+        compareDates(el.end_date)
       );
       setEventsInProgress(eventsInProgress);
 
-      const endedEvents = data.data.filter((el) =>
-        isEndedEvent(today, el.end_date)
-      );
+      const endedEvents = data.data.filter((el) => !compareDates(el.end_date));
       setEndedEvents(endedEvents);
     },
   });
@@ -94,7 +74,7 @@ const AdminEvent = (): JSX.Element => {
   });
 
   const OpenModal = () => {
-    setModalState((prev) => {
+    setModalState(() => {
       return 'add';
     });
     dispatch(modalAction.radioAdminEventModal());
@@ -113,7 +93,7 @@ const AdminEvent = (): JSX.Element => {
         ...data.data,
       };
     });
-    setModalState((prev) => {
+    setModalState(() => {
       return 'edit';
     });
     setTimeout(() => {

--- a/src/routes/home/home.component.tsx
+++ b/src/routes/home/home.component.tsx
@@ -1,16 +1,14 @@
-import { useEffect } from 'react';
-import { useAppDispatch, useAppSelector } from '../../hooks/index.hook';
-import { fetchAllEvents } from '../../api/event';
-import { fetchPopularStay } from '../../api/popular-stay';
-import { selectAllEvents } from '../../store/modules/event/event.select';
-import { selectPopularStay } from '../../store/modules/popular-stay/popularStay.select';
+import { useQuery } from '@tanstack/react-query';
+import { compareDates } from '../../utils/compareDates';
+import { GetAllEventsSuccessResponse } from '../../components/swiper/eventSwiper.component';
 
 import Container from '../../components/container/container.component';
 import Header from '../../components/header/header.component';
 import Footer from '../../components/footer/footer.component';
-import SwiperComponent from '../../components/swiper/swiper.component';
 import UserInfoModal from '../../components/user-info-modal/userInfoModal.component';
-import BannerSwiper from '../../components/banner-swiper/bannerSwiper.component';
+import BannerSwiper from '../../components/swiper/bannerSwiper.component';
+import EventSwiper from '../../components/swiper/eventSwiper.component';
+import StaySwiper from '../../components/swiper/staySwiper.component';
 
 import {
   MainBanner,
@@ -18,44 +16,33 @@ import {
   SliderTitle,
   Wrapper,
 } from './home.style';
-import { navigatorAction } from '../../store/modules/navigator/navigator.slice';
 
 export default function Home(): JSX.Element {
-  const dispatch = useAppDispatch();
-
-  const events = useAppSelector(selectAllEvents);
-  const popularStays = useAppSelector(selectPopularStay);
-
-  useEffect(() => {
-    dispatch(navigatorAction.setCurrnetPage('home'));
-    const fetchData = async () => {
-      await dispatch(fetchAllEvents());
-      await dispatch(fetchPopularStay());
-    };
-
-    fetchData();
-  }, [dispatch]);
-
-  const BANNER_IMAGES = [
-    'https://d2u1fvsvew9tft.cloudfront.net/plus/1658500098920이벤트배너.png',
-    'https://d2u1fvsvew9tft.cloudfront.net/plus/1658498830946이벤트배너2.png',
-  ];
+  const { data } = useQuery<GetAllEventsSuccessResponse>(['allEvents'], {});
 
   return (
     <Container>
       <Wrapper>
         <MainBanner>
-          <BannerSwiper imgUrlArr={BANNER_IMAGES} />
+          <BannerSwiper />
         </MainBanner>
+
+        {data &&
+          data.data.filter((el) => compareDates(el.end_date)).length !== 0 && (
+            <SliderContainer>
+              <SliderTitle>현재 진행중인 이벤트</SliderTitle>
+              <EventSwiper />
+            </SliderContainer>
+          )}
 
         <SliderContainer>
           <SliderTitle>현재 진행중인 이벤트</SliderTitle>
-          <SwiperComponent swiperDataArr={events}></SwiperComponent>
+          <EventSwiper />
         </SliderContainer>
 
         <SliderContainer>
           <SliderTitle>혼자와서 둘이가는 인기순</SliderTitle>
-          <SwiperComponent swiperDataArr={popularStays}></SwiperComponent>
+          <StaySwiper />
         </SliderContainer>
 
         <Header />

--- a/src/utils/compareDates.ts
+++ b/src/utils/compareDates.ts
@@ -1,3 +1,7 @@
+// 인자로 받은 날짜와 오늘 날짜를 비교
+// 받은 날짜가 오늘 날짜보다 앞이면(지났으면) false,
+// 뒤면(안 지났으면) true 리턴
+
 export const compareDates = (inputDate: string) => {
   const today = new Date();
   const year = today.getFullYear();

--- a/src/utils/compareDates.ts
+++ b/src/utils/compareDates.ts
@@ -1,0 +1,12 @@
+export const compareDates = (inputDate: string) => {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = today.getMonth() + 1;
+  const date = today.getDate();
+
+  const todayDate = `${year}-${month < 10 ? `0${month}` : month}-${
+    date < 10 ? `0${date}` : date
+  }`;
+
+  return inputDate >= todayDate;
+};


### PR DESCRIPTION
## 📑 작업내역 요약
### 문제점
메인화면에서 종료된 이벤트에 대한 예외처리가 되어 있지 않아서 종료된 이벤트도 보이는 문제

### 해결
오늘날짜와 종료 날짜를 비교해서 기간이 지난 이벤트는 보이지 않도록 처리

## 📎 관련 이슈
resolve #18

## ✔️ 셀프 체크리스트
- [✔️] Warning Message가 발생하지 않았나요?
- [✔️] Coding Convention을 준수했나요?

## 💬 작업 내용
- 인자로 날짜(yyyy-MM-dd 형식)를 받아서 오늘 날짜보다 앞이면(지났으면) false, 뒤면(안 지났으면) true를 반환하는 함수 구현
- 오늘 날짜와 이벤트 종료기간을 비교해서 이미 종료된 이벤트면 안보여지게 처리
- swiper.component를 이벤트와 인기 숙소 따로 분리
- 현재 진행중인 이벤트가 없을 때 메인화면에서 타이틀 포함해서 아예 제거
 
## 🚧 PR 특이 사항
없습니다~